### PR TITLE
Drewware

### DIFF
--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/32mz_interrupt_control.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/32mz_interrupt_control.c
@@ -41,7 +41,7 @@ void setGlobalInterruptsState(uint8_t input_state) {
 void setInterruptEnable(interrupt_source_t input_interrupt, uint8_t input_state) {
  
     // Mask off anything larger than 1 to 1
-    input_state = input_state >= 1;
+    // input_state = input_state >= 1;
     
     // Decide which interrupt control bits to manipulate based on which interrupt
     // is being enabled or disabled
@@ -1719,7 +1719,7 @@ uint8_t getInterruptEnable(interrupt_source_t input_interrupt) {
 void setInterruptFlag(interrupt_source_t input_interrupt, uint8_t input_state) {
  
     // Mask off anything larger than 1 to 1
-    input_state = input_state >= 1;
+    // input_state = input_state >= 1;
     
     // Decide which interrupt control bits to manipulate based on which interrupt
     // is being enabled or disabled

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
@@ -18,6 +18,7 @@
 #ifndef _CONFIGURE_H    /* Guard against multiple inclusion */
 #define _CONFIGURE_H
 
+
 // PIC32MZ2048EFH144 Configuration Bit Settings
 
 // 'C' source line config statements
@@ -41,7 +42,7 @@
 
 // DEVCFG1
 #pragma config FNOSC = SPLL             // Oscillator Selection Bits (System PLL)
-#pragma config DMTINTV = WIN_0          // DMT Count Window Interval (Window/Interval value is zero)
+#pragma config DMTINTV = WIN_127_128    // DMT Count Window Interval (Window/Interval value is 127/128 counter value)
 #pragma config FSOSCEN = OFF            // Secondary Oscillator Enable (Disable SOSC)
 #pragma config IESO = OFF               // Internal/External Switch Over (Disabled)
 #pragma config POSCMOD = OFF            // Primary Oscillator Configuration (Primary osc disabled)
@@ -53,7 +54,7 @@
 #pragma config FWDTEN = ON              // Watchdog Timer Enable (WDT Enabled)
 #pragma config FWDTWINSZ = WINSZ_75     // Watchdog Timer Window Size (Window size is 75%)
 #pragma config DMTCNT = DMT31           // Deadman Timer Count Selection (2^31 (2147483648))
-#pragma config FDMTEN = OFF             // Deadman Timer Enable (Deadman Timer is disabled)
+#pragma config FDMTEN = ON              // Deadman Timer Enable (Deadman Timer is enabled)
 
 // DEVCFG0
 #pragma config DEBUG = OFF              // Background Debugger Enable (Debugger is disabled)
@@ -87,7 +88,6 @@
 // DEVADC4
 
 // DEVADC7
-
 
 #endif /* _CONFIGURE_H */
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
@@ -18,14 +18,13 @@
 #ifndef _CONFIGURE_H    /* Guard against multiple inclusion */
 #define _CONFIGURE_H
 
-// Configuration bits
-// PIC32MZ2048EFH144 Primary Configuration Bit Settings
+// PIC32MZ2048EFH144 Configuration Bit Settings
 
 // 'C' source line config statements
 
 // DEVCFG3
 // USERID = No Setting
-#pragma config FMIIEN = ON              // Ethernet RMII/MII Enable (MII Enabled)
+#pragma config FMIIEN = OFF             // Ethernet RMII/MII Enable (RMII Enabled)
 #pragma config FETHIO = ON              // Ethernet I/O Pin Select (Default Ethernet I/O)
 #pragma config PGL1WAY = ON             // Permission Group Lock One Way Configuration (Allow only one reconfiguration)
 #pragma config PMDL1WAY = ON            // Peripheral Module Disable Configuration (Allow only one reconfiguration)
@@ -42,23 +41,23 @@
 
 // DEVCFG1
 #pragma config FNOSC = SPLL             // Oscillator Selection Bits (System PLL)
-#pragma config DMTINTV = WIN_127_128    // DMT Count Window Interval (Window/Interval value is 127/128 counter value)
+#pragma config DMTINTV = WIN_0          // DMT Count Window Interval (Window/Interval value is zero)
 #pragma config FSOSCEN = OFF            // Secondary Oscillator Enable (Disable SOSC)
 #pragma config IESO = OFF               // Internal/External Switch Over (Disabled)
 #pragma config POSCMOD = OFF            // Primary Oscillator Configuration (Primary osc disabled)
 #pragma config OSCIOFNC = OFF           // CLKO Output Signal Active on the OSCO Pin (Disabled)
 #pragma config FCKSM = CSECME           // Clock Switching and Monitor Selection (Clock Switch Enabled, FSCM Enabled)
-#pragma config WDTPS = PS1048576        // Watchdog Timer Postscaler (1:1048576)
+#pragma config WDTPS = PS2048           // Watchdog Timer Postscaler (1:2048)
 #pragma config WDTSPGM = STOP           // Watchdog Timer Stop During Flash Programming (WDT stops during Flash programming)
 #pragma config WINDIS = NORMAL          // Watchdog Timer Window Mode (Watchdog Timer is in non-Window mode)
-#pragma config FWDTEN = OFF             // Watchdog Timer Enable (WDT Disabled)
-#pragma config FWDTWINSZ = WINSZ_25     // Watchdog Timer Window Size (Window size is 25%)
+#pragma config FWDTEN = ON              // Watchdog Timer Enable (WDT Enabled)
+#pragma config FWDTWINSZ = WINSZ_75     // Watchdog Timer Window Size (Window size is 75%)
 #pragma config DMTCNT = DMT31           // Deadman Timer Count Selection (2^31 (2147483648))
 #pragma config FDMTEN = OFF             // Deadman Timer Enable (Deadman Timer is disabled)
 
 // DEVCFG0
 #pragma config DEBUG = OFF              // Background Debugger Enable (Debugger is disabled)
-#pragma config JTAGEN = OFF             // JTAG Enable (JTAG disabled)
+#pragma config JTAGEN = OFF             // JTAG Enable (JTAG Disabled)
 #pragma config ICESEL = ICS_PGx1        // ICE/ICD Comm Channel Select (Communicate on PGEC1/PGED1)
 #pragma config TRCEN = OFF              // Trace Enable (Trace features in the CPU are disabled)
 #pragma config BOOTISA = MIPS32         // Boot ISA Selection (Boot code and Exception code is MIPS32)
@@ -66,7 +65,7 @@
 #pragma config FSLEEP = OFF             // Flash Sleep Mode (Flash is powered down when the device is in Sleep mode)
 #pragma config DBGPER = PG_ALL          // Debug Mode CPU Access Permission (Allow CPU access to all permission regions)
 #pragma config SMCLR = MCLR_NORM        // Soft Master Clear Enable bit (MCLR pin generates a normal system Reset)
-#pragma config SOSCGAIN = GAIN_2X      // Secondary Oscillator Gain Control bits (2x gain setting)
+#pragma config SOSCGAIN = GAIN_2X       // Secondary Oscillator Gain Control bits (2x gain setting)
 #pragma config SOSCBOOST = ON           // Secondary Oscillator Boost Kick Start Enable bit (Boost the kick start of the oscillator)
 #pragma config POSCGAIN = GAIN_2X       // Primary Oscillator Gain Control bits (2x gain setting)
 #pragma config POSCBOOST = ON           // Primary Oscillator Boost Kick Start Enable bit (Boost the kick start of the oscillator)
@@ -75,64 +74,19 @@
 // DEVCP0
 #pragma config CP = OFF                 // Code Protect (Protection Disabled)
 
+// SEQ3
 
-// PIC32MZ2048EFH144 Alternate Configuration Bit Settings
+// DEVADC0
 
-// 'C' source line config statements
+// DEVADC1
 
-// ADEVCFG3
-// USERID = No Setting
-#pragma config_alt FMIIEN = ON          // Ethernet RMII/MII Enable (MII Enabled)
-#pragma config_alt FETHIO = ON          // Ethernet I/O Pin Select (Default Ethernet I/O)
-#pragma config_alt PGL1WAY = ON         // Permission Group Lock One Way Configuration (Allow only one reconfiguration)
-#pragma config_alt PMDL1WAY = ON        // Peripheral Module Disable Configuration (Allow only one reconfiguration)
-#pragma config_alt IOL1WAY = ON         // Peripheral Pin Select Configuration (Allow only one reconfiguration)
-#pragma config_alt FUSBIDIO = ON        // USB USBID Selection (Controlled by the USB Module)
+// DEVADC2
 
-// ADEVCFG2
-#pragma config_alt FPLLIDIV = DIV_1     // System PLL Input Divider (1x Divider)
-#pragma config_alt FPLLRNG = RANGE_5_10_MHZ// System PLL Input Range (5-10 MHz Input)
-#pragma config_alt FPLLICLK = PLL_FRC   // System PLL Input Clock Selection (FRC is input to the System PLL)
-#pragma config_alt FPLLMULT = MUL_63    // System PLL Multiplier (PLL Multiply by 63)
-#pragma config_alt FPLLODIV = DIV_2     // System PLL Output Clock Divider (2x Divider)
-#pragma config_alt UPLLFSEL = FREQ_24MHZ// USB PLL Input Frequency Selection (USB PLL input is 24 MHz)
+// DEVADC3
 
-// ADEVCFG1
-#pragma config_alt FNOSC = SPLL         // Oscillator Selection Bits (System PLL)
-#pragma config_alt DMTINTV = WIN_127_128// DMT Count Window Interval (Window/Interval value is 127/128 counter value)
-#pragma config_alt FSOSCEN = OFF        // Secondary Oscillator Enable (Disable SOSC)
-#pragma config_alt IESO = OFF           // Internal/External Switch Over (Disabled)
-#pragma config_alt POSCMOD = OFF        // Primary Oscillator Configuration (Primary osc disabled)
-#pragma config_alt OSCIOFNC = OFF       // CLKO Output Signal Active on the OSCO Pin (Disabled)
-#pragma config_alt FCKSM = CSECME       // Clock Switching and Monitor Selection (Clock Switch Enabled, FSCM Enabled)
-#pragma config_alt WDTPS = PS1048576    // Watchdog Timer Postscaler (1:1048576)
-#pragma config_alt WDTSPGM = STOP       // Watchdog Timer Stop During Flash Programming (WDT stops during Flash programming)
-#pragma config_alt WINDIS = NORMAL      // Watchdog Timer Window Mode (Watchdog Timer is in non-Window mode)
-#pragma config_alt FWDTEN = OFF         // Watchdog Timer Enable (WDT Disabled)
-#pragma config_alt FWDTWINSZ = WINSZ_25 // Watchdog Timer Window Size (Window size is 25%)
-#pragma config_alt DMTCNT = DMT31       // Deadman Timer Count Selection (2^31 (2147483648))
-#pragma config_alt FDMTEN = OFF         // Deadman Timer Enable (Deadman Timer is disabled)
+// DEVADC4
 
-// ADEVCFG0
-#pragma config_alt DEBUG = OFF          // Background Debugger Enable (Debugger is disabled)
-#pragma config_alt JTAGEN = OFF         // JTAG Enable (JTAG Disabled)
-#pragma config_alt ICESEL = ICS_PGx1    // ICE/ICD Comm Channel Select (Communicate on PGEC1/PGED1)
-#pragma config_alt TRCEN = ON           // Trace Enable (Trace features in the CPU are enabled)
-#pragma config_alt BOOTISA = MIPS32     // Boot ISA Selection (Boot code and Exception code is MIPS32)
-#pragma config_alt FECCCON = OFF_UNLOCKED// Dynamic Flash ECC Configuration (ECC and Dynamic ECC are disabled (ECCCON bits are writable))
-#pragma config_alt FSLEEP = OFF         // Flash Sleep Mode (Flash is powered down when the device is in Sleep mode)
-#pragma config_alt DBGPER = PG_ALL      // Debug Mode CPU Access Permission (Allow CPU access to all permission regions)
-#pragma config_alt SMCLR = MCLR_NORM    // Soft Master Clear Enable bit (MCLR pin generates a normal system Reset)
-#pragma config_alt SOSCGAIN = GAIN_2X   // Secondary Oscillator Gain Control bits (2x gain setting)
-#pragma config_alt SOSCBOOST = ON       // Secondary Oscillator Boost Kick Start Enable bit (Boost the kick start of the oscillator)
-#pragma config_alt POSCGAIN = GAIN_2X   // Primary Oscillator Gain Control bits (2x gain setting)
-#pragma config_alt POSCBOOST = ON       // Primary Oscillator Boost Kick Start Enable bit (Boost the kick start of the oscillator)
-#pragma config_alt EJTAGBEN = NORMAL    // EJTAG Boot (Normal EJTAG functionality)
-
-// ADEVCP0
-#pragma config_alt CP = OFF             // Code Protect (Protection Disabled)
-
-
+// DEVADC7
 
 
 #endif /* _CONFIGURE_H */

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c
@@ -100,6 +100,18 @@ void deviceReset(void) {
     
 }
 
+// This function is a software delay that simply counts loops while decrementing
+// the argument
+void softwareDelay(uint32_t inputDelay) {
+ 
+    while (inputDelay > 0) {
+     
+        inputDelay--;
+        
+    }
+    
+}
+
 // This function initializes the oscillator and PLL
 // This sets up a SYSCLK of 252 MHz
 // REFCLK1: Disabled

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.h
@@ -37,6 +37,10 @@ void deviceLock(void);
 // This function resets the microcontroller
 void deviceReset(void);
 
+// This function is a software delay that simply counts loops while decrementing
+// the argument
+void softwareDelay(uint32_t inputDelay);
+
 // This function initializes the system clocks
 void clockInitialize(void);
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/gpio_setup.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/gpio_setup.c
@@ -293,7 +293,7 @@ void portDGPIOInitialize (void){
     
     // Setup RD10
     TRISDbits.TRISD10   = TRIS_OUTPUT;
-    LATDbits.LATD10     = LAT_LOW;
+    LATDbits.LATD10     = LAT_HIGH;
     ODCDbits.ODCD10     = ODC_DISABLE;
     RPD10R              = 0b0001;       // Set RD10 as UART 3 TX
     

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/gpio_setup.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/gpio_setup.c
@@ -145,10 +145,10 @@ void portBGPIOInitialize (void){
     ANSELBbits.ANSB7    = ANALOG_DISABLE;
     
     // Setup RB8
-    TRISBbits.TRISB3    = TRIS_OUTPUT;
-    LATBbits.LATB3      = LAT_LOW;
-    ODCBbits.ODCB3      = ODC_DISABLE;
-    ANSELBbits.ANSB3    = ANALOG_DISABLE;
+    TRISBbits.TRISB8    = TRIS_OUTPUT;
+    LATBbits.LATB8      = LAT_LOW;
+    ODCBbits.ODCB8      = ODC_DISABLE;
+    ANSELBbits.ANSB8    = ANALOG_DISABLE;
     
     // Setup RB9
     TRISBbits.TRISB9    = TRIS_OUTPUT;

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
@@ -68,19 +68,7 @@ void heartbeatTimerStop(void) {
 void __ISR(_TIMER_1_VECTOR, ipl1AUTO) hearbeatTimerISR(void) {
 
     // Disable timer 1 interrupt
-    disableInterrupt(Timer1);
-    
-    // TO-DO: Do we need to copy RIPL bits into IPL bits?
-    // This is from section 8.7.1 of micro reference manual (interrupt group priority levels)
-    // Apparently this is how you block lower level interrupts during a higher order
-    // ISR. If this is needed it should be done at beginning on EVERY ISR
-    // The compiler may actually do this for us in the background
-    // That could be what the ipl<priority> keyword does in above __ISR() macro
-    // Leave AUTO keyword in there, that handles context saving in ISRs
-    // Seeing how the device macros header file does not include any references to RIPL
-    // and IPL or CPU registers Cause and Status, most likely we're not responsible for this
-    // Definitely look deeper into this though, because if this is our problem
-    // and we miss this, interrupts will not be prioritized
+    // disableInterrupt(Timer1);
     
     // Toggle heartbeat LED
     HEARTBEAT_LED_PIN = !(HEARTBEAT_LED_PIN);
@@ -103,7 +91,7 @@ void __ISR(_TIMER_1_VECTOR, ipl1AUTO) hearbeatTimerISR(void) {
     clearInterruptFlag(Timer1);
     
     // Re-enable interrupt
-    enableInterrupt(Timer1);
+    // enableInterrupt(Timer1);
     
 
 }

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
@@ -89,7 +89,7 @@ void __ISR(_TIMER_1_VECTOR, ipl1AUTO) hearbeatTimerISR(void) {
     device_on_time_counter++;
     
     // Clear the watchdog timer
-    // kickTheDog();
+    kickTheDog();
     
     // Clear the deadman timer
     // holdThumbTighter();

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
@@ -31,14 +31,17 @@ void heartbeatTimerInitialize(void) {
     // This will give an interrupt rate of 1 Hz
     PR1 = 61523;
     
-    // Enable timer 1 interrupt
-    enableInterrupt(Timer1);
+    // Clear Timer1 Interrupt Flag
+    clearInterruptFlag(Timer1);
     
     // Set Timer 1 interrupt priority
     setInterruptPriority(Timer1, 1);
     
     // Clear on time counter
     device_on_time_counter = 0;
+    
+    // Enable timer 1 interrupt
+    enableInterrupt(Timer1);
     
     // Start timer 1
     T1CONbits.ON = 1;
@@ -86,10 +89,10 @@ void __ISR(_TIMER_1_VECTOR, ipl1AUTO) hearbeatTimerISR(void) {
     device_on_time_counter++;
     
     // Clear the watchdog timer
-    kickTheDog();
+    // kickTheDog();
     
     // Clear the deadman timer
-    holdThumbTighter();
+    // holdThumbTighter();
     
     // TO-DO: If we're going to keep track of display on time with a counter, increment it here too
     

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c
@@ -92,7 +92,10 @@ void __ISR(_TIMER_1_VECTOR, ipl1AUTO) hearbeatTimerISR(void) {
     kickTheDog();
     
     // Clear the deadman timer
-    // holdThumbTighter();
+    holdThumbTighter();
+    
+    // Check to see if DMT actually cleared
+    verifyThumbTightEnough();
     
     // TO-DO: If we're going to keep track of display on time with a counter, increment it here too
     

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -58,15 +58,17 @@
 // Miscellaneous Board Control
 #include "misc_board_control.h"
 
+// USB UART Command Ready Flag
+extern volatile uint8_t usb_uart_RxStringReady;
+
 // Main program entry point
 void main(void) {
     
-        
-    // Enable Global Interrupts
-    enableGlobalInterrupts();
-    
     // Enable multi-vector interrupt mode
     INTCONbits.MVEC = 1;
+    
+    // Enable Global Interrupts
+    enableGlobalInterrupts();
     
     // Initialize system clocks
     clockInitialize();
@@ -125,6 +127,13 @@ void main(void) {
         
         // Twiddle thumbs
         Nop();
+                
+        // Check if we've got a received USB UART command waiting
+        if(usb_uart_RxStringReady) {
+
+            USB_UART_ringBufferPull();
+        
+        }
         
         
     }

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -81,6 +81,7 @@ void main(void) {
     
     // Print debug message
     USB_UART_print(" System Boot\n\r");
+    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
     USB_UART_print("Clocks Initialized to the following settings:\n\r");
     USB_UART_print("    SYSCLK: 252 MHz\n\r"
                    "    REFCLK1: Disabled\n\r"
@@ -121,6 +122,8 @@ void main(void) {
     // Turn off RESET LED
     nACTIVE_LED_PIN = 0;
     USB_UART_print("Reset LED disabled\n\r");
+    
+    USB_UART_textAttributesReset();
     
     // Loop endlessly
     while (true) {

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -80,7 +80,7 @@ void main(void) {
     heartbeatTimerInitialize();
     
     // Setup the watchdog timer
-    // watchdogTimerInitialize();
+    watchdogTimerInitialize();
     
     // Startup the deadman timer
     // deadmanTimerInitialize();
@@ -90,8 +90,6 @@ void main(void) {
     
     // Turn off RESET LED
     nACTIVE_LED_PIN = 0;
-    
-    POS5_RUN_PIN = 1;
     
     // Loop endlessly
     while (true) {

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -61,35 +61,64 @@
 // Main program entry point
 void main(void) {
     
+        
+    // Enable Global Interrupts
+    enableGlobalInterrupts();
+    
+    // Enable multi-vector interrupt mode
+    INTCONbits.MVEC = 1;
+    
     // Initialize system clocks
     clockInitialize();
-    
+        
     // Initialize GPIO pins to startup settings
     gpioInitialize();
     
     // Initialize UART USB debugging
-    // USB_UART_Initialize();
+    USB_UART_Initialize();
     
     // Print debug message
-    // USB_UART_print("Clocks, GPIO and USB UART initialized\n\r");
-    
-    // Disable unused peripherals for power savings
-    // PMDInitialize();
+    USB_UART_print(" System Boot\n\r");
+    USB_UART_print("Clocks Initialized to the following settings:\n\r");
+    USB_UART_print("    SYSCLK: 252 MHz\n\r"
+                   "    REFCLK1: Disabled\n\r"
+                   "    REFCLK2: Disabled\n\r"
+                   "    REFCLK3: Disabled\n\r"
+                   "    REFCLK4: Disabled\n\r"
+                   "    PBCLK1: 84 MHz\n\r"
+                   "    PBCLK2: 84 MHz\n\r"
+                   "    PBCLK3: 15.75 MHz\n\r"
+                   "    PBCLK4: 84 MHz\n\r"
+                   "    PBCLK5: 84 MHz\n\r"
+                   "    PBCLK7: 252 MHz\n\r"
+                   "    PBCLK8: 84 MHz\n\r");   
+    USB_UART_print("GPIO Pins Initialized\n\r");
+    USB_UART_print("USB UART Initialized to the following settings:\n\r"
+                   "    Baud Rate: 115.2 kbs\n\r"
+                   "    Data Length: 8 bits\n\r"
+                   "    Parity: None\n\r"
+                   "    Stop Bits: 1\n\r"
+                   "    Flow Control: None\n\r");
     
     // Setup heartbeat timer
     heartbeatTimerInitialize();
+    USB_UART_print("Heartbeat Timer Initialized\n\r");
     
+    // Disable unused peripherals for power savings
+    PMDInitialize();
+    USB_UART_print("Peripheral Module Disable Initialized for reduced power consumption\n\r");
+            
     // Setup the watchdog timer
     watchdogTimerInitialize();
+    USB_UART_print("Watchdog Timer Initialized with a timeout of 2.048 seconds\n\r");
     
     // Startup the deadman timer
     deadmanTimerInitialize();
-    
-    // Enable Global Interrupts
-    enableGlobalInterrupts();
+    USB_UART_print("Deadman Timer Initialized with a timeout of 2147483648 instruction fetches\n\r");
     
     // Turn off RESET LED
     nACTIVE_LED_PIN = 0;
+    USB_UART_print("Reset LED disabled\n\r");
     
     // Loop endlessly
     while (true) {

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -68,22 +68,30 @@ void main(void) {
     gpioInitialize();
     
     // Initialize UART USB debugging
-    USB_UART_Initialize();
+    // USB_UART_Initialize();
     
     // Print debug message
-    USB_UART_print("Clocks, GPIO and USB UART initialized\n\r");
+    // USB_UART_print("Clocks, GPIO and USB UART initialized\n\r");
     
     // Disable unused peripherals for power savings
-    PMDInitialize();
+    // PMDInitialize();
     
     // Setup heartbeat timer
     heartbeatTimerInitialize();
     
     // Setup the watchdog timer
-    watchdogTimerInitialize();
+    // watchdogTimerInitialize();
     
     // Startup the deadman timer
-    deadmanTimerInitialize();
+    // deadmanTimerInitialize();
+    
+    // Enable Global Interrupts
+    enableGlobalInterrupts();
+    
+    // Turn off RESET LED
+    nACTIVE_LED_PIN = 0;
+    
+    POS5_RUN_PIN = 1;
     
     // Loop endlessly
     while (true) {

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -83,7 +83,7 @@ void main(void) {
     watchdogTimerInitialize();
     
     // Startup the deadman timer
-    // deadmanTimerInitialize();
+    deadmanTimerInitialize();
     
     // Enable Global Interrupts
     enableGlobalInterrupts();
@@ -96,7 +96,8 @@ void main(void) {
         
         // Twiddle thumbs
         Nop();
-    
+        
+        
     }
     
     

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
@@ -57,17 +57,17 @@ OBJECTDIR=build/${CND_CONF}/${IMAGE_TYPE}
 DISTDIR=dist/${CND_CONF}/${IMAGE_TYPE}
 
 # Source Files Quoted if spaced
-SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c device_control.c cause_of_reset.c 32mz_interrupt_control.c main.c watchdog_timer.c
+SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c
 
 # Object Files Quoted if spaced
-OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/main.o ${OBJECTDIR}/watchdog_timer.o
-POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/main.o.d ${OBJECTDIR}/watchdog_timer.o.d
+OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o
+POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/watchdog_timer.o.d ${OBJECTDIR}/main.o.d
 
 # Object Files
-OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/main.o ${OBJECTDIR}/watchdog_timer.o
+OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o
 
 # Source Files
-SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c device_control.c cause_of_reset.c 32mz_interrupt_control.c main.c watchdog_timer.c
+SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c
 
 
 CFLAGS=
@@ -190,17 +190,17 @@ ${OBJECTDIR}/32mz_interrupt_control.o: 32mz_interrupt_control.c  nbproject/Makef
 	@${RM} ${OBJECTDIR}/32mz_interrupt_control.o 
 	@${FIXDEPS} "${OBJECTDIR}/32mz_interrupt_control.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/32mz_interrupt_control.o.d" -o ${OBJECTDIR}/32mz_interrupt_control.o 32mz_interrupt_control.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
-${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} "${OBJECTDIR}" 
-	@${RM} ${OBJECTDIR}/main.o.d 
-	@${RM} ${OBJECTDIR}/main.o 
-	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
-	
 ${OBJECTDIR}/watchdog_timer.o: watchdog_timer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/watchdog_timer.o.d 
 	@${RM} ${OBJECTDIR}/watchdog_timer.o 
 	@${FIXDEPS} "${OBJECTDIR}/watchdog_timer.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/watchdog_timer.o.d" -o ${OBJECTDIR}/watchdog_timer.o watchdog_timer.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
+${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/main.o.d 
+	@${RM} ${OBJECTDIR}/main.o 
+	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
 else
 ${OBJECTDIR}/gpio_setup.o: gpio_setup.c  nbproject/Makefile-${CND_CONF}.mk
@@ -287,17 +287,17 @@ ${OBJECTDIR}/32mz_interrupt_control.o: 32mz_interrupt_control.c  nbproject/Makef
 	@${RM} ${OBJECTDIR}/32mz_interrupt_control.o 
 	@${FIXDEPS} "${OBJECTDIR}/32mz_interrupt_control.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/32mz_interrupt_control.o.d" -o ${OBJECTDIR}/32mz_interrupt_control.o 32mz_interrupt_control.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
-${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} "${OBJECTDIR}" 
-	@${RM} ${OBJECTDIR}/main.o.d 
-	@${RM} ${OBJECTDIR}/main.o 
-	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
-	
 ${OBJECTDIR}/watchdog_timer.o: watchdog_timer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/watchdog_timer.o.d 
 	@${RM} ${OBJECTDIR}/watchdog_timer.o 
 	@${FIXDEPS} "${OBJECTDIR}/watchdog_timer.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/watchdog_timer.o.d" -o ${OBJECTDIR}/watchdog_timer.o watchdog_timer.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
+${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/main.o.d 
+	@${RM} ${OBJECTDIR}/main.o 
+	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
 endif
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
@@ -1,5 +1,5 @@
 #
-#Mon Jan 28 13:42:11 CST 2019
+#Mon Jan 28 21:54:34 CST 2019
 default.com-microchip-mplab-nbide-toolchainXC32-XC32LanguageToolchain.md5=f03d7c843128b5e50a1f7aa63f2ccfb5
 default.languagetoolchain.dir=C\:\\Program Files (x86)\\Microchip\\xc32\\v2.10\\bin
 configurations-xml=7b2b899edc549541f9a30fe08f47e403

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
@@ -1,8 +1,8 @@
 #
-#Mon Jan 07 21:21:28 CST 2019
+#Mon Jan 28 13:42:11 CST 2019
 default.com-microchip-mplab-nbide-toolchainXC32-XC32LanguageToolchain.md5=f03d7c843128b5e50a1f7aa63f2ccfb5
 default.languagetoolchain.dir=C\:\\Program Files (x86)\\Microchip\\xc32\\v2.10\\bin
-configurations-xml=968fa6b2db9fe9d4d9331282ee60a6de
+configurations-xml=7b2b899edc549541f9a30fe08f47e403
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=ddd77f39013c5d7ceec7afa039614a52
 default.languagetoolchain.version=2.10
 host.platform=windows

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
@@ -233,6 +233,9 @@
         <property key="save-temps" value="false"/>
         <property key="wpo-lto" value="false"/>
       </C32Global>
+      <PICkit3PlatformTool>
+        <property key="firmware.download.all" value="false"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
@@ -402,9 +402,94 @@ void USB_UART_ringBufferLUT(char * line_in) {
         
     }
     
-    else if (strcmp(line_in, "Hello") == 0) {
+    else if (strcmp(line_in, "Clear") == 0) {
      
-        USB_UART_print("Hello back\n\r");
+        USB_UART_clearTerminal();
+        USB_UART_setCursorHome();
+        
+    }
+    
+    else if (strcmp(line_in, "*IDN?") == 0) {
+     
+        USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+        USB_UART_print("E44 Electronic Display Logic Board\n\r");
+        USB_UART_textAttributesReset();
+        
+    }
+    
+    else if (strcmp(line_in, "Print Test Message") == 0) {
+        
+        USB_UART_printTestMessage();
+        
+    }
+    
+    else if (strcmp(line_in, "Credits") == 0) {
+     
+        USB_UART_textAttributes(YELLOW, BLUE, BOLD);
+        USB_UART_print("Marquette Senior Design 2018-2019\n\r");
+        USB_UART_textAttributesReset();
+        USB_UART_printNewline();
+        USB_UART_textAttributes(BLUE, YELLOW, BOLD);
+        USB_UART_print("Team E44: EECE Office LED Display\n\r");
+        USB_UART_textAttributesReset();
+        USB_UART_printNewline();
+        USB_UART_textAttributes(CYAN, BLACK, NORMAL);
+        USB_UART_print("Logan Wedel\n\r");
+        USB_UART_textAttributes(YELLOW, BLACK, NORMAL);
+        USB_UART_print("Caroline Gilger\n\r");
+        USB_UART_textAttributes(RED, BLACK, NORMAL);
+        USB_UART_print("Drew Maatman\n\r");
+        USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+        USB_UART_print("Kevin Etta\n\r");
+        USB_UART_textAttributes(MAGENTA, BLACK, NORMAL);
+        USB_UART_print("Tuoxuan Ren\n\r");
+        USB_UART_textAttributesReset();
+        USB_UART_printNewline();
+        
+    }
+    
+    else if (strcmp(line_in, "Help") == 0) {
+    
+        USB_UART_printHelpMessage();
+        
+    }
+    
+    else if (strcmp(line_in, "POS5 Enable") == 0) {
+     
+        POS5_RUN_PIN = 1;
+        
+        USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+        USB_UART_print("POS5 RUN Asserted\n\r");
+        USB_UART_textAttributesReset();
+        
+    }
+    
+    else if (strcmp(line_in, "POS5 Disable") == 0) {
+     
+        POS5_RUN_PIN = 0;
+        
+        USB_UART_textAttributes(RED, BLACK, NORMAL);
+        USB_UART_print("POS5 RUN Deasserted\n\r");
+        USB_UART_textAttributesReset();
+        
+    }
+    
+    else if (strcmp(line_in, "POS5P Enable") == 0) {
+     
+        POS5P_RUN_PIN = 1;
+        USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+        USB_UART_print("POS5P RUN Asserted\n\r");
+        USB_UART_textAttributesReset();
+        
+    }
+    
+    else if (strcmp(line_in, "POS5P Disable") == 0) {
+     
+        POS5P_RUN_PIN = 0;
+        
+        USB_UART_textAttributes(RED, BLACK, NORMAL);
+        USB_UART_print("POS5P RUN Deasserted\n\r");
+        USB_UART_textAttributesReset();
         
     }
     
@@ -571,47 +656,37 @@ void USB_UART_printHelpMessage(void) {
  
     USB_UART_textAttributes(YELLOW, BLACK, NORMAL);
     USB_UART_print("Supported Commands:\n\r");
-    USB_UART_print("    LED On: Sets RE3\n\r");
-    USB_UART_print("    LED Off: Clears RE3\n\r");
     USB_UART_print("    Reset: Software Reset\n\r");
     USB_UART_print("    Clear: Clears the terminal\n\r");
     USB_UART_print("    *IDN?: Returns identification string\n\r");
-    USB_UART_print("    Enable Muxing: enables the multiplexing timer \n\r");
-    USB_UART_print("    Disable Muxing: disable the multiplexing timer \n\r");
-    USB_UART_print("    Device On Time?: Returns the device on time in seconds since last reset\n\r");
-    USB_UART_print("    Print Test Message: Print out terminal test data\n\r");
-    USB_UART_print("    Credits: Displays creators\n\r");
+    USB_UART_print("    POS5 Enable: Turns on the on board +5V Power Supply for level shifters\n\r");
+    USB_UART_print("    POS5 Disable: Turns off the on board +5V Power Supply for level shifters\n\r");
+    USB_UART_print("    POS5P Enable: Turns on the external +5V Power Supply for LED panels\n\r");
+    USB_UART_print("    POS5P Disable: Turns off the external +5V Power Supply for LED panels\n\r");
+//     USB_UART_print("    Enable Muxing: enables the multiplexing timer \n\r");
+//     USB_UART_print("    Disable Muxing: disable the multiplexing timer \n\r");
+//     USB_UART_print("    Device On Time?: Returns the device on time in seconds since last reset\n\r");
+     USB_UART_print("    Print Test Message: Print out terminal test data\n\r");
+//     USB_UART_print("    Credits: Displays creators\n\r");
     USB_UART_print("    Help: This Command\n\r");
-    USB_UART_print("    Set Red: Sets panels red\n\r");
-    USB_UART_print("    Set White: Sets panels white\n\r");    
-    USB_UART_print("    Set Blue: Sets panels blue\n\r");
-    USB_UART_print("    Set Yellow: Sets panels yellow\n\r");
-    USB_UART_print("    Set Cyan: Sets panels cyan\n\r");    
-    USB_UART_print("    Set Green: Sets panels green\n\r");    
-    USB_UART_print("    Set Magenta: Sets panels magenta\n\r");    
-    USB_UART_print("    Set MU Logo: Sets panel as MU Logo static image\n\r");
-    USB_UART_print("    Set Rand: Sets panel to random data\n\r");
-    USB_UART_print("    Set Test Image 2: Fills ram buffer with kevin's second test image\n\r");
-    USB_UART_print("    Set Every Other Red: Fills ram buffer with stripes of red\n\r");
-    USB_UART_print("    Set Every Other Blue: Fills ram buffer with stripes of blue\n\r");
-    USB_UART_print("    Set Every Other Green: Fills ram buffer with stripes of green\n\r");
-    USB_UART_print("    Set Christmas Stripes: Fills ram buffer with christmas stripes\n\r");
-    USB_UART_print("    Set RGB Stripes: Fills ram buffer with stripes of rgb\n\r");
-    USB_UART_print("    Set Red Rows: Fills ram buffer with red rows\n\r");
-    USB_UART_print("    Set Shocker: Displays an inappropriate test image\n\r");
-    USB_UART_print("    Set Drew 2: Displays drews second test image\n\r");
-    USB_UART_print("    Slow Muxing Speed: Slows down multiplexing\n\r");
-    USB_UART_print("    Slowest Muxing Speed: Slows down muxing speed extremely\n\r");
-    USB_UART_print("    Reset Muxing Speed: Resets to faster multiplexing speed\n\r");
-    USB_UART_print("    Set TV Test: Fills ram buffer with TV Test image\n\r");
-    USB_UART_print("    Set NFL: Fills ram buffer with kevin's NFL image\n\r");
-    USB_UART_print("    Set Colors: Fills ram buffer with colors\n\r");
-    USB_UART_print("    Set Addidas: Fills ram buffer with addidas image\n\r");
-    USB_UART_print("    Set BMW: Fills ram buffer with BMW logo\n\r");
-    USB_UART_print("    Set Fire: Fills ram buffer with fire\n\r");
-    USB_UART_print("    Set Swirl: Fills ram buffer with swirl image\n\r");
-    USB_UART_print("    Set Bosch: Fills ram buffer with bosch image\n\r");
-    USB_UART_print("    Set Kevin: Fills ram buffer with kevin image\n\r");
+//    USB_UART_print("    Set Red: Sets panels red\n\r");
+//    USB_UART_print("    Set White: Sets panels white\n\r");    
+//    USB_UART_print("    Set Blue: Sets panels blue\n\r");
+//    USB_UART_print("    Set Yellow: Sets panels yellow\n\r");
+//    USB_UART_print("    Set Cyan: Sets panels cyan\n\r");    
+//    USB_UART_print("    Set Green: Sets panels green\n\r");    
+//    USB_UART_print("    Set Magenta: Sets panels magenta\n\r");    
+//    USB_UART_print("    Set MU Logo: Sets panel as MU Logo static image\n\r");
+//    USB_UART_print("    Set Rand: Sets panel to random data\n\r");
+//    USB_UART_print("    Set Every Other Red: Fills ram buffer with stripes of red\n\r");
+//    USB_UART_print("    Set Every Other Blue: Fills ram buffer with stripes of blue\n\r");
+//    USB_UART_print("    Set Every Other Green: Fills ram buffer with stripes of green\n\r");
+//    USB_UART_print("    Set Christmas Stripes: Fills ram buffer with christmas stripes\n\r");
+//    USB_UART_print("    Set RGB Stripes: Fills ram buffer with stripes of rgb\n\r");
+//    USB_UART_print("    Set Red Rows: Fills ram buffer with red rows\n\r");
+//    USB_UART_print("    Slow Muxing Speed: Slows down multiplexing\n\r");
+//    USB_UART_print("    Slowest Muxing Speed: Slows down muxing speed extremely\n\r");
+//    USB_UART_print("    Reset Muxing Speed: Resets to faster multiplexing speed\n\r");
     
     USB_UART_textAttributesReset();
 
@@ -623,11 +698,13 @@ void USB_UART_printTestMessage(void) {
     // Set starting text color white, background black, no fancy stuff
     // Print COM port settings
     USB_UART_textAttributesReset();
+    USB_UART_clearTerminal();
+    USB_UART_setCursorHome();
     USB_UART_print("Hello, World!\n\r");
     USB_UART_print("PIC32MZ USB UART Test\n\r");
     USB_UART_printNewline();
     USB_UART_print("COM Port Settings:\n\r");
-    USB_UART_print("    Baud Rate: 921600 bps\n\r");
+    USB_UART_print("    Baud Rate: 115200 bps\n\r");
     USB_UART_print("    Data: 8 bits\n\r");
     USB_UART_print("    Parity: None\n\r");
     USB_UART_print("    Stop: 1 bit\n\r");

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
@@ -12,6 +12,7 @@
 #include "pin_macros.h"
 #include "device_control.h"
 #include "usb_uart.h"
+#include "error_handler.h"
 
 
 // Text attribute enums
@@ -168,6 +169,7 @@ void __ISR(_UART3_TX_VECTOR, ipl3AUTO) USB_UART_Transfer_ISR(void) {
 void __ISR(_UART3_FAULT_VECTOR, ipl1AUTO) USB_UART_Fault_ISR(void) {
     
     // TO-DO: Fault tasks
+    error_handler.USB_error_flag = 1;
     
     // Clear fault interrupt flag
     clearInterruptFlag(UART3_Fault);

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.h
@@ -20,8 +20,8 @@
 #include <sys/attribs.h>
 
 // Sizes of TX and RX ring buffers
-#define USB_UART_TX_BUFFER_SIZE 64
-#define USB_UART_RX_BUFFER_SIZE 64
+#define USB_UART_TX_BUFFER_SIZE 256
+#define USB_UART_RX_BUFFER_SIZE 256
 
 // Output character buffer
 char output_buff[USB_UART_TX_BUFFER_SIZE];
@@ -32,8 +32,8 @@ char output_buff[USB_UART_TX_BUFFER_SIZE];
 char USB_UART_line[USB_UART_RX_BUFFER_SIZE];
 
 // ring buffer counters
-extern volatile uint8_t usb_uart_TxBufferRemaining;
-extern volatile uint8_t usb_uart_RxCount;
+extern volatile uint32_t usb_uart_TxBufferRemaining;
+extern volatile uint32_t usb_uart_RxCount;
 
 
 // Enumeration holding attributes data for setting text fanciness

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/watchdog_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/watchdog_timer.c
@@ -1,6 +1,5 @@
 
 #include <xc.h>
-#include <proc/p32mz2048efh144.h>
 
 #include "watchdog_timer.h"
 
@@ -13,17 +12,6 @@ void watchdogTimerInitialize(void) {
     
     // Disable WDT window (window always open)
     WDTCONbits.WDTWINEN = 0;
-    
-    // Modify configuration words to set WDT postscaler to 1:2048
-    // This yields a timeout period of 2.048 seconds
-    DEVCFG1bits.WDTPS = 0b01011;
-    
-    // Verify WDTPS change actually occurred
-    if (DEVCFG1bits.WDTPS != 0b01011) {
-     
-        error_handler.configuration_error_flag = 1;
-        
-    }
     
     // Start the watchdog timer
     WDTCONbits.ON = 1;


### PR DESCRIPTION
Resolved a lot of issues transferring old Harmony code into bare metal on logic board. This includes watchdog timer, deadman timer, USB UART (for the most part), heartbeat timer, and some other random issues.