### PR TITLE
Renamed USB functions, moved terminal control functions to new module

### DIFF
--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/32mz_interrupt_control.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/32mz_interrupt_control.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 #include "32mz_interrupt_control.h"
-#include "usb_uart.h"
+#include "terminal_control.h"
 
 
 // This function enables global interrupts
@@ -7000,19 +7000,19 @@ char * getInterruptNameStringPadded(interrupt_source_t input_interrupt) {
 // This function prints information on all interrupt settings
 void printInterruptStatus(void) {
     
-    // USB_UART_textAttributesReset();
-    USB_UART_textAttributes(GREEN, BLACK, UNDERSCORE);
+    terminalTextAttributesReset();
+    terminalTextAttributes(GREEN, BLACK, UNDERSCORE);
     printf("Interrupt Status:\n\r");
 
-    USB_UART_textAttributesReset();
+    terminalTextAttributesReset();
     
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("Global Interrupt Enable: %s\n\r", getGlobalInterruptsState() ? "T" : "F");
 
-    USB_UART_textAttributes(GREEN, BLACK, REVERSE);
-    printf("###  Name                    EN?  P S\n\r");
+    terminalTextAttributes(GREEN, BLACK, REVERSE);
+    printf("###  Name                    EN?  P S IRQ?\n\r");
     
-    USB_UART_textAttributesReset();
+    terminalTextAttributesReset();
 
     // Loop through all possible interrupts
     uint8_t i;
@@ -7020,23 +7020,26 @@ void printInterruptStatus(void) {
      
         if (i % 2 == 0) {
          
-            USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+            terminalTextAttributes(GREEN, BLACK, NORMAL);
             
         }
         
         else {
          
-            USB_UART_textAttributes(GREEN, BLACK, BLINK);
+            terminalTextAttributes(GREEN, BLACK, BLINK);
             
         }
         
-        printf("%03d  %s%c  %d %d\n\r", 
+        printf("%03d  %s%c  %d %d    %c\n\r", 
                 i,
                 getInterruptNameStringPadded(i),
                 getInterruptEnable(i) ? 'T' : ' ',
                 getInterruptPriority(i),
-                getInterruptSubriority(i));
+                getInterruptSubriority(i),
+                getInterruptFlag(i) ? 'T' : ' ');
 
     }
-        
+
+    terminalTextAttributesReset();    
+    
 }

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -41,6 +41,8 @@
 #include "heartbeat_timer.h"
 // Power saving APIs (PMD, SLEEP, etc)
 #include "power_saving.h"
+// Terminal control for USB debugging
+#include "terminal_control.h"
 // USB debugging
 #include "usb_uart.h"
 // External Bus Interface (EBI)
@@ -86,12 +88,12 @@ void main(void) {
     coreTimerInitialize();
     
     // Initialize UART USB debugging
-    USB_UART_Initialize();
+    usbUartInitialize();
     
     // Clear the terminal
-    USB_UART_clearTerminal();
-    USB_UART_setCursorHome();
-    USB_UART_textAttributesReset();
+    terminalClearScreen();
+    terminalSetCursorHome();
+    terminalTextAttributesReset();
 
     
     // Print debug message s
@@ -107,20 +109,20 @@ void main(void) {
             reset_cause == External_Reset ||
             reset_cause == BOR_Reset) {
     
-        USB_UART_textAttributes(RED, BLACK, BOLD);
+        terminalTextAttributes(RED, BLACK, BOLD);
         
     }
     
     else {
      
-        USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+        terminalTextAttributes(GREEN, BLACK, NORMAL);
         
     }
     
     printf("Cause of most recent device reset: %s\n\r", getResetCauseString(reset_cause));
     
-    USB_UART_textAttributesReset();
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributesReset();
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("Clocks Initialized\n\r");
     
     printf("GPIO Pins Initialized\n\r");
@@ -151,10 +153,10 @@ void main(void) {
     nACTIVE_LED_PIN = 0;
     printf("Reset LED disabled\n\r");
     
-    USB_UART_textAttributesReset();
-    USB_UART_textAttributes(YELLOW, BLACK, NORMAL);
+    terminalTextAttributesReset();
+    terminalTextAttributes(YELLOW, BLACK, NORMAL);
     printf("\n\rType 'Help' for list of supported commands, press enter twice after reset\n\r\n\r");
-    USB_UART_textAttributesReset();
+    terminalTextAttributesReset();
     
     // Lock configurations
     deviceLock();
@@ -168,7 +170,7 @@ void main(void) {
         // Check if we've got a received USB UART command waiting
         if(usb_uart_RxStringReady != 0) {
 
-            USB_UART_ringBufferPull();
+            usbUartRingBufferPull();
         
         }
         

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
@@ -57,17 +57,17 @@ OBJECTDIR=build/${CND_CONF}/${IMAGE_TYPE}
 DISTDIR=dist/${CND_CONF}/${IMAGE_TYPE}
 
 # Source Files Quoted if spaced
-SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c
+SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c terminal_control.c
 
 # Object Files Quoted if spaced
-OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o
-POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/external_bus_interface.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/watchdog_timer.o.d ${OBJECTDIR}/main.o.d
+OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o ${OBJECTDIR}/terminal_control.o
+POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/external_bus_interface.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/watchdog_timer.o.d ${OBJECTDIR}/main.o.d ${OBJECTDIR}/terminal_control.o.d
 
 # Object Files
-OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o
+OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/main.o ${OBJECTDIR}/terminal_control.o
 
 # Source Files
-SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c
+SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c main.c terminal_control.c
 
 
 CFLAGS=
@@ -208,6 +208,12 @@ ${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
 	@${RM} ${OBJECTDIR}/main.o 
 	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
+${OBJECTDIR}/terminal_control.o: terminal_control.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/terminal_control.o.d 
+	@${RM} ${OBJECTDIR}/terminal_control.o 
+	@${FIXDEPS} "${OBJECTDIR}/terminal_control.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/terminal_control.o.d" -o ${OBJECTDIR}/terminal_control.o terminal_control.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
 else
 ${OBJECTDIR}/gpio_setup.o: gpio_setup.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
@@ -310,6 +316,12 @@ ${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
 	@${RM} ${OBJECTDIR}/main.o.d 
 	@${RM} ${OBJECTDIR}/main.o 
 	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
+${OBJECTDIR}/terminal_control.o: terminal_control.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/terminal_control.o.d 
+	@${RM} ${OBJECTDIR}/terminal_control.o 
+	@${FIXDEPS} "${OBJECTDIR}/terminal_control.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/terminal_control.o.d" -o ${OBJECTDIR}/terminal_control.o terminal_control.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
 endif
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
@@ -1,8 +1,8 @@
 #
-#Fri Feb 01 16:18:45 CST 2019
+#Sun Feb 03 12:12:43 CST 2019
 default.com-microchip-mplab-nbide-toolchainXC32-XC32LanguageToolchain.md5=f03d7c843128b5e50a1f7aa63f2ccfb5
 default.languagetoolchain.dir=C\:\\Program Files (x86)\\Microchip\\xc32\\v2.10\\bin
-configurations-xml=198c3eab0f77700e3b1395308879f050
+configurations-xml=689c10246a36163d07bed83bbd9f7003
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=ddd77f39013c5d7ceec7afa039614a52
 default.languagetoolchain.version=2.10
 host.platform=windows

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
@@ -18,6 +18,7 @@
         <itemPath>adc.h</itemPath>
         <itemPath>misc_board_control.h</itemPath>
         <itemPath>rotary_encoder.h</itemPath>
+        <itemPath>terminal_control.h</itemPath>
       </logicalFolder>
       <logicalFolder name="f1" displayName="Device Control" projectFiles="true">
         <itemPath>device_control.h</itemPath>
@@ -47,6 +48,7 @@
         <itemPath>misc_board_control.c</itemPath>
         <itemPath>rotary_encoder.c</itemPath>
         <itemPath>external_bus_interface.c</itemPath>
+        <itemPath>terminal_control.c</itemPath>
       </logicalFolder>
       <logicalFolder name="f1" displayName="Device Control" projectFiles="true">
         <itemPath>device_control.c</itemPath>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #include "power_saving.h"
-#include "usb_uart.h"
+#include "terminal_control.h"
 
 
 // This function disables unused peripherals on startup for power savings
@@ -130,174 +130,178 @@ void PMDInitialize(void) {
 
 // This function prints the status of PMD settings
 void printPMDStatus(void) {
+
+    terminalTextAttributesReset();    
     
-    USB_UART_textAttributes(GREEN, BLACK, UNDERSCORE);
+    terminalTextAttributes(GREEN, BLACK, UNDERSCORE);
     printf("Peripheral Module Disable Status:\n\r");
     
     // ADC
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   ADC Enabled:                              %s\n\r", PMD1bits.ADCMD ? " " : "T");
     
     // CVREF
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Comparator Voltage Reference Enabled:     %s\n\r", PMD1bits.CVRMD ? " " : "T");
     
     // Comparators
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Comparator 1 Enabled:                     %s\n\r", PMD2bits.CMP1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Comparator 2 Enabled:                     %s\n\r", PMD2bits.CMP2MD ? " " : "T");
     
     // Input Capture Modules:
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Input Capture 1 Enabled:                  %s\n\r", PMD3bits.IC1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Input Capture 2 Enabled:                  %s\n\r", PMD3bits.IC2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Input Capture 3 Enabled:                  %s\n\r", PMD3bits.IC3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Input Capture 4 Enabled:                  %s\n\r", PMD3bits.IC4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Input Capture 5 Enabled:                  %s\n\r", PMD3bits.IC5MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Input Capture 6 Enabled:                  %s\n\r", PMD3bits.IC6MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Input Capture 7 Enabled:                  %s\n\r", PMD3bits.IC7MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Input Capture 8 Enabled:                  %s\n\r", PMD3bits.IC8MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Input Capture 9 Enabled:                  %s\n\r", PMD3bits.IC9MD ? " " : "T");
     
     // Output Compare Modules
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Output Compare 1 Enabled:                 %s\n\r", PMD3bits.OC1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Output Compare 2 Enabled:                 %s\n\r", PMD3bits.OC2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Output Compare 3 Enabled:                 %s\n\r", PMD3bits.OC3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Output Compare 4 Enabled:                 %s\n\r", PMD3bits.OC4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Output Compare 5 Enabled:                 %s\n\r", PMD3bits.OC5MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Output Compare 6 Enabled:                 %s\n\r", PMD3bits.OC6MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Output Compare 7 Enabled:                 %s\n\r", PMD3bits.OC7MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Output Compare 8 Enabled:                 %s\n\r", PMD3bits.OC8MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Output Compare 9 Enabled:                 %s\n\r", PMD3bits.OC9MD ? " " : "T");
     
     // Timers
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Timer 1 Enabled:                          %s\n\r", PMD4bits.T1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Timer 2 Enabled:                          %s\n\r", PMD4bits.T2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Timer 3 Enabled:                          %s\n\r", PMD4bits.T3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Timer 4 Enabled:                          %s\n\r", PMD4bits.T4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Timer 5 Enabled:                          %s\n\r", PMD4bits.T5MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Timer 6 Enabled:                          %s\n\r", PMD4bits.T6MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Timer 7 Enabled:                          %s\n\r", PMD4bits.T7MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Timer 8 Enabled:                          %s\n\r", PMD4bits.T8MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Timer 9 Enabled:                          %s\n\r", PMD4bits.T9MD ? " " : "T");
     
     // UART Modules
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   UART 1 Enabled:                           %s\n\r", PMD5bits.U1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   UART 2 Enabled:                           %s\n\r", PMD5bits.U2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   UART 3 Enabled:                           %s\n\r", PMD5bits.U3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   UART 4 Enabled:                           %s\n\r", PMD5bits.U4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   UART 5 Enabled:                           %s\n\r", PMD5bits.U5MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   UART 6 Enabled:                           %s\n\r", PMD5bits.U6MD ? " " : "T");
     
     // SPI Modules
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   SPI 1 Enabled:                            %s\n\r", PMD5bits.SPI1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   SPI 2 Enabled:                            %s\n\r", PMD5bits.SPI2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   SPI 3 Enabled:                            %s\n\r", PMD5bits.SPI3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   SPI 4 Enabled:                            %s\n\r", PMD5bits.SPI4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   SPI 5 Enabled:                            %s\n\r", PMD5bits.SPI5MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   SPI 6 Enabled:                            %s\n\r", PMD5bits.SPI6MD ? " " : "T");
     
     // I2C Modules
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   I2C 1 Enabled:                            %s\n\r", PMD5bits.I2C1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   I2C 2 Enabled:                            %s\n\r", PMD5bits.I2C2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   I2C 3 Enabled:                            %s\n\r", PMD5bits.I2C3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   I2C 4 Enabled:                            %s\n\r", PMD5bits.I2C4MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   I2C 5 Enabled:                            %s\n\r", PMD5bits.I2C5MD ? " " : "T");
     
     // USB Module
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   USB Enabled:                              %s\n\r", PMD5bits.USBMD ? " " : "T");
     
     // CAN Modules
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   CAN 1 Enabled:                            %s\n\r", PMD5bits.CAN1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   CAN 2 Enabled:                            %s\n\r", PMD5bits.CAN2MD ? " " : "T");
     
     // RTCC
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Real Time Clock Enabled:                  %s\n\r", PMD6bits.RTCCMD ? " " : "T");
     
     // REFCLKS
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Reference Clock 1 Enabled:                %s\n\r", PMD6bits.REFO1MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Reference Clock 2 Enabled:                %s\n\r", PMD6bits.REFO2MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Reference Clock 3 Enabled:                %s\n\r", PMD6bits.REFO3MD ? " " : "T");
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Reference Clock 4 Enabled:                %s\n\r", PMD6bits.REFO4MD ? " " : "T");
     
     // PMP
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Parallel Master Port Enabled:             %s\n\r", PMD6bits.PMPMD ? " " : "T");
     
     // EBI
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   External Bus Interface Enabled:           %s\n\r", PMD6bits.EBIMD ? " " : "T");
     
     // SQI
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Serial Quad Interface Enabled:            %s\n\r", PMD6bits.SQI1MD ? " " : "T");
     
     // Ethernet
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Ethernet Enabled:                         %s\n\r", PMD6bits.ETHMD ? " " : "T");
     
     // DMA
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   Direct Memory Access Enabled:             %s\n\r", PMD7bits.DMAMD ? " " : "T");
     
     // Random Number Generator
-    USB_UART_textAttributes(GREEN, BLACK, BLINK);
+    terminalTextAttributes(GREEN, BLACK, BLINK);
     printf("   Random Number Generator Enabled:          %s\n\r", PMD7bits.RNGMD ? " " : "T");
     
     // PMD Locked?
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("   PMD Locked:                               %s\n\r", CFGCONbits.PMDLOCK ? "T" : "F");
+    
+    terminalTextAttributesReset();
     
 }

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/terminal_control.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/terminal_control.c
@@ -1,0 +1,273 @@
+
+#include <xc.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "terminal_control.h"
+#include "usb_uart.h"
+
+
+// This function clears the terminal
+void terminalClearScreen(void) {
+    printf("\033[2J");
+}
+
+// This function moves the terminal cursor to top left corner
+void terminalSetCursorHome(void) {
+    printf("\033[H");
+}
+
+// This function clears the line the cursor is currently at on the terminal
+void terminalClearLine(void) {
+    printf("\033[K");
+}
+
+// This function saves the current cursor position on the terminal
+void terminalSaveCursor(void) {
+    printf("\033[s");
+}
+
+// This function returns the cursor to saved position on terminal
+void terminalReturnCursor(void) {
+    printf("\033[u");
+}
+
+// Text attributes function
+// See attributes enums in "USB_UART.h"
+// Call like so:
+/*
+
+    USB_UART_textAttributes(<TEXT COLOR (ALL CAPS)>, 
+                            <BACKGROUND COLOR (ALL CAPS)>, 
+                            <TEXT EFFECT (ALL CAPS)>);
+
+*/
+
+void terminalTextAttributes(text_color_t foreground_color,
+        text_color_t background_color,
+        text_attribute_t input_attribute) {
+    
+    char print_string[16];
+    
+    // Null print string
+    uint8_t i;
+    for (i = 0; i < sizeof(print_string); i++) {
+     
+        print_string[i] = '\0';
+        
+    }
+    
+    strncpy(print_string, "\033[", sizeof(print_string));
+    
+    switch (input_attribute) {
+     
+        case NORMAL:
+            strcat(print_string,"0");
+            break;
+        case BOLD:
+            strcat(print_string,"1");
+            break;
+        case UNDERSCORE:
+            strcat(print_string,"4");
+            break;
+        case BLINK:
+            strcat(print_string,"5");
+            break;
+        case REVERSE:
+            strcat(print_string,"7");
+            break;
+        case CONCEALED:
+            strcat(print_string,"8");
+            break;
+
+        default:
+            strcat(print_string,"0");
+            break;
+    }
+    
+    strcat(print_string,";");
+    
+    switch (foreground_color) {
+     
+        case BLACK:
+            strcat(print_string,"30");
+            break;
+        case RED:
+            strcat(print_string,"31");
+            break;
+        case GREEN:
+            strcat(print_string,"32");
+            break;
+        case YELLOW:
+            strcat(print_string,"33");
+            break;
+        case BLUE:
+            strcat(print_string,"34");
+            break;
+        case MAGENTA:
+            strcat(print_string,"35");
+            break;
+        case CYAN:
+            strcat(print_string,"36");
+            break;
+        case WHITE:
+            strcat(print_string,"37");
+            break;
+            
+        default:
+            strcat(print_string,"37");
+            break;
+    }
+    
+    strcat(print_string,";");
+    
+    switch (background_color) {
+     
+        case BLACK:
+            strcat(print_string,"40");
+            break;
+        case RED:
+            strcat(print_string,"41");
+            break;
+        case GREEN:
+            strcat(print_string,"42");
+            break;
+        case YELLOW:
+            strcat(print_string,"43");
+            break;
+        case BLUE:
+            strcat(print_string,"44");
+            break;
+        case MAGENTA:
+            strcat(print_string,"45");
+            break;
+        case CYAN:
+            strcat(print_string,"46");
+            break;
+        case WHITE:
+            strcat(print_string,"47");
+            break;
+            
+        default:
+            strcat(print_string,"40");
+            break;
+    }
+    
+    strcat(print_string,"m");
+    
+    printf(print_string);
+    
+}
+
+// Reset text attributes to white text, black background, no effects
+void terminalTextAttributesReset(void) {
+ 
+    // USB_UART_textAttributes(WHITE, BLACK, NORMAL);
+    printf("\033[0;37;40m");
+    
+}
+
+// tests all the function written for this example
+void terminalPrintTestMessage(void) {
+    
+    // Set starting text color white, background black, no fancy stuff
+    // Print COM port settings
+    terminalTextAttributesReset();
+    terminalClearScreen();
+    terminalSetCursorHome();
+    printf("USB UART Test\n\r\n\r");
+    printf("COM Port Settings:\n\r");
+    printf("    Baud Rate: %s\n\r", USB_UART_BAUD_RATE_STR);
+    printf("    Data Length: %s\n\r", USB_UART_DATA_LENGTH_STR);
+    printf("    Parity: %\n\r", USB_UART_PARITY_STR);
+    printf("    Stop Bits: %s\n\r", USB_UART_STOP_BITS_STR);
+    printf("    Flow Control: %s\n\r\n\r", USB_UART_FLOW_CONTROL_STR);
+        
+    // Test text attributes
+    printf("Testing text attributes:\n\r");
+
+    // Print some black text
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, WHITE, NORMAL);
+    printf("This text is black\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(RED, BLACK, NORMAL);
+    printf("This text is red\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
+    printf("This text is green\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(YELLOW, BLACK, NORMAL);
+    printf("This text is yellow\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLUE, WHITE, NORMAL);
+    printf("This text is blue\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(MAGENTA, BLACK, NORMAL);
+    printf("This text is magenta\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(CYAN, BLACK, NORMAL);
+    printf("This text is cyan\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLACK, NORMAL);
+    printf("This text has a black background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, RED, NORMAL);
+    printf("This text has a red background\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, GREEN, NORMAL);
+    printf("This text has a green background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, YELLOW, NORMAL);
+    printf("This text has a yellow background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLUE, NORMAL);
+    printf("This text has a blue background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, MAGENTA, NORMAL);
+    printf("This text has a magenta background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, CYAN, NORMAL);
+    printf("This text has a cyan background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(BLACK, WHITE, NORMAL);
+    printf("This text has a white background\n\r");
+    
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLACK, BOLD);
+    printf("This text is bold\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLACK, UNDERSCORE);
+    printf("This text is underscored\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLACK, BLINK);
+    printf("This text is blinking\n\r");
+
+    terminalTextAttributesReset();
+    terminalTextAttributes(WHITE, BLACK, REVERSE);
+    printf("This text is reversed\n\r");
+
+    terminalTextAttributesReset();
+    printf("This text is normal\n\r\n\r");
+    
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
+    printf("Finished test message, type 'Help' for list of commands\n\r\n\r");
+    terminalTextAttributesReset();
+
+}

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/terminal_control.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/terminal_control.h
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/** Terminal Control Functions for serial terminals
+ */
+/* ************************************************************************** */
+
+#ifndef _TERMINAL_CONTROL_H    /* Guard against multiple inclusion */
+#define _TERMINAL_CONTROL_H
+
+
+// Enumeration holding attributes data for setting text fanciness
+typedef enum {
+    
+    NORMAL,
+    BOLD,
+    UNDERSCORE,
+    BLINK,
+    REVERSE,
+    CONCEALED
+            
+} text_attribute_t;
+
+// Enumeration for setting text color attributes
+typedef enum {
+    
+    BLACK,
+    RED,
+    GREEN,
+    YELLOW,
+    BLUE,
+    MAGENTA,
+    CYAN,
+    WHITE
+            
+} text_color_t;
+
+// Terminal manipulation functions
+void terminalClearScreen(void);  // clears the whole terminal
+void terminalSetCursorHome(void);  // Sets cursor to home position (top left)
+void terminalClearLine(void);      // clears the current line where the cursor appears
+void terminalSaveCursor(void);     // Saves the current position of the cursor
+void terminalReturnCursor(void);   // Returns the cursor to saved position
+
+// Text attributes function
+void terminalTextAttributes(text_color_t foreground_color,
+        text_color_t background_color,
+        text_attribute_t input_attribute);
+
+// Reset to white foreground, black background, no fancy stuff
+void terminalTextAttributesReset(void);
+
+// This function tests terminal control
+void terminalPrintTestMessage(void);
+
+
+
+#endif /* _TERMINAL_CONTROL_H */
+
+/* *****************************************************************************
+ End of File
+ */

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.h
@@ -32,7 +32,7 @@
 
 // Received String from EUSART rx ring buffer, this is what we actually compare
 // against command strings
-char USB_UART_line[USB_UART_RX_BUFFER_SIZE];
+char usb_uart_line[USB_UART_RX_BUFFER_SIZE];
 
 // ring buffer counters
 extern volatile uint32_t usb_uart_RxBufferRemaining;
@@ -44,78 +44,30 @@ extern volatile uint64_t usb_uart_TxBufferRemaining;
 extern volatile uint8_t usb_uart_TxBuffer[USB_UART_TX_BUFFER_SIZE];
 
 
-
-// Enumeration holding attributes data for setting text fanciness
-typedef enum {
-    
-    NORMAL,
-    BOLD,
-    UNDERSCORE,
-    BLINK,
-    REVERSE,
-    CONCEALED
-            
-} text_attribute_t;
-
-// Enumeration for setting text color attributes
-typedef enum {
-    
-    BLACK,
-    RED,
-    GREEN,
-    YELLOW,
-    BLUE,
-    MAGENTA,
-    CYAN,
-    WHITE
-            
-} text_color_t;
-
-
 // This function initializes UART 6 for USB debugging
-void USB_UART_Initialize(void);
+void usbUartInitialize(void);
 
 // These are the USB UART Interrupt Service Routines
-void __ISR(_UART3_RX_VECTOR, ipl2AUTO) USB_UART_Receive_ISR(void);
-void __ISR(_UART3_TX_VECTOR, ipl3AUTO) USB_UART_Transfer_ISR(void);
-void __ISR(_UART3_FAULT_VECTOR, ipl1AUTO) USB_UART_Fault_ISR(void);
+void __ISR(_UART3_RX_VECTOR, ipl2AUTO) usbUartReceiveISR(void);
+void __ISR(_UART3_TX_VECTOR, ipl3AUTO) usbUartTransferISR(void);
+void __ISR(_UART3_FAULT_VECTOR, ipl1AUTO) usbUartFaultISR(void);
 
-// This function allows reading of a byre from UART6
-uint8_t USB_UART_Read_Byte(void);
+// This function allows reading of a byre from UART3
+uint8_t usbUartReadByte(void);
 
-// This function places a character into the output stream of UART6
-void USB_UART_putchar(uint8_t txData);
+// This function places a character into the output stream of UART3
+void usbUartPutchar(uint8_t txData);
 
 // These are the UART6 interrupt handlers
-void USB_UART_Transmit_Handler(void);
-void USB_UART_Receive_Handler(void);
-
-// Basic text output function, feed it a string, everything is built off of this
-void USB_UART_print(char charArray[]);
+void usbUartTransmitHandler(void);
+void usbUartReceiveHandler(void);
 
 // Ring buffer interface functions
-void USB_UART_ringBufferPull(void);
-void USB_UART_ringBufferLUT(char * USB_UART_line);
-
-// Terminal manipulation functions
-void USB_UART_clearTerminal(void);  // clears the whole terminal
-void USB_UART_setCursorHome(void);  // Sets cursor to home position
-void USB_UART_clearLine(void);      // clears the current line where the cursor appears
-void USB_UART_saveCursor(void);     // Saves the current position of the cursor
-void USB_UART_returnCursor(void);   // Returns the cursor to saved position
-
-// Text attributes function
-void USB_UART_textAttributes(text_color_t foreground_color,
-        text_color_t background_color,
-        text_attribute_t input_attribute);
-
-// Reset to white foreground, black background, no fancy stuff
-void USB_UART_textAttributesReset(void);
+void usbUartRingBufferPull(void);
+void usbUartRingBufferLUT(char * USB_UART_line);
 
 // Misc functions
-void USB_UART_printNewline(void);
-void USB_UART_printHelpMessage(void);
-void USB_UART_printTestMessage(void);
+void usbUartPrintHelpMessage(void);
 
 
 // This function returns a string of a large number of seconds in a human readable format

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/watchdog_timer.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/watchdog_timer.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #include "watchdog_timer.h"
-#include "usb_uart.h"
+#include "terminal_control.h"
 #include "pin_macros.h"
 
 // This function initializes the watchdog timer for a timeout period of 
@@ -96,10 +96,11 @@ void verifyThumbTightEnough(void) {
 // This function prints information on the watchdog timer
 void printWatchdogStatus(void) {
 
-    USB_UART_textAttributes(GREEN, BLACK, UNDERSCORE);
+    terminalTextAttributesReset();
+    terminalTextAttributes(GREEN, BLACK, UNDERSCORE);
     printf("Watchdog Timer Status:\n\r");
 
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     printf("    Postscalar: ");
     
     switch (DEVCFG1bits.WDTPS) {
@@ -239,16 +240,19 @@ void printWatchdogStatus(void) {
         printf("False\n\r");
         
     }
+    
+    terminalTextAttributesReset();
 
 }
 
 // This function prints information on the deadman timer
 void printDeadmanStatus(void) {
 
-    USB_UART_textAttributes(GREEN, BLACK, UNDERSCORE);
+    terminalTextAttributesReset();
+    terminalTextAttributes(GREEN, BLACK, UNDERSCORE);
     printf("Deadman Timer Status:\n\r");
 
-    USB_UART_textAttributes(GREEN, BLACK, NORMAL);
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
     
     printf("   Instruction Fetch Count Limit: ");
     
@@ -307,6 +311,8 @@ void printDeadmanStatus(void) {
         printf("False\n\r");
         
     }
+    
+    terminalTextAttributesReset();
        
 }
 


### PR DESCRIPTION
Now terminal control does not require specific usb_uart module, it just uses printf, and all other modules that have print messages don't require specific usb_uart module, they just require terminal control and stdio.

This closes:
closes #73 and closes #72 