### PR TITLE
Drewware

### DIFF
--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h
@@ -75,7 +75,7 @@
 #pragma config CP = OFF                 // Code Protect (Protection Disabled)
 
 #pragma config TSEQ = 0xffff
-#pragma config CSEQ = 0xffff
+#pragma config CSEQ = 0x0000
 
 // SEQ3
 
@@ -143,8 +143,8 @@
 // ADEVCP0
 #pragma config_alt CP = OFF             // Code Protect (Protection Disabled)
 
-#pragma config_alt TSEQ = 0xffff
-#pragma config_alt CSEQ = 0xffff
+#pragma config_alt TSEQ = 0xfffe
+#pragma config_alt CSEQ = 00001
 
 // ASEQ3
 
@@ -200,8 +200,8 @@
 // AUBADEVCP0
 #pragma config_auba CP = OFF            // Code Protect (Protection Disabled)
 
-#pragma config_auba TSEQ = 0xffff
-#pragma config_auba CSEQ = 0xffff
+#pragma config_auba TSEQ = 0xfffd
+#pragma config_auba CSEQ = 0x0002
 
 // AUBASEQ3
 
@@ -257,8 +257,8 @@
 // UBADEVCP0
 #pragma config_uba CP = OFF             // Code Protect (Protection Disabled)
 
-#pragma config_uba TSEQ = 0xffff
-#pragma config_uba CSEQ = 0xffff
+#pragma config_uba TSEQ = 0xfffc
+#pragma config_uba CSEQ = 00003
 
 #endif /* _CONFIGURE_H */
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c
@@ -789,15 +789,24 @@ void printClockStatus(uint32_t input_sysclk) {
     else terminalTextAttributes(RED, BLACK, NORMAL);
     printf("\n\r    Dream Mode %s\n\r", OSCCONbits.DRMEN ? "Enabled" : "Disabled");
     
-    // Print PLL status
+    // Print boot PLL status
     terminalTextAttributes(GREEN, BLACK, NORMAL);
-    printf("\n\r    PLL Input Divider is set to: %d\n\r", (DEVCFG2bits.FPLLIDIV + 1));
-    printf("    PLL Multiplier is set to: %d\n\r", (DEVCFG2bits.FPLLMULT + 1));
-    printf("    PLL Output Divider is set to: %d\n\r", (DEVCFG2bits.FPLLODIV + 1));
+    printf("\n\r    Boot PLL Input Divider is set to: %d\n\r", (DEVCFG2bits.FPLLIDIV + 1));
+    printf("    Boot PLL Multiplier is set to: %d\n\r", (DEVCFG2bits.FPLLMULT + 1));
+    printf("    Boot PLL Output Divider is set to: %d\n\r", (DEVCFG2bits.FPLLODIV + 1));
     
-    printf("    Overall PLL Gain is: %.3f\n\r", 
+    printf("    Overall Boot PLL Gain is: %.3f\n\r", 
             (float) (DEVCFG2bits.FPLLMULT + 1) / ((DEVCFG2bits.FPLLIDIV) + (DEVCFG2bits.FPLLODIV) + 1));
     
+    
+    // Print changed PLL status
+    terminalTextAttributes(GREEN, BLACK, NORMAL);
+    printf("\n\r    Operational PLL Input Divider is set to: %d\n\r", (SPLLCONbits.PLLIDIV + 1));
+    printf("    Operational PLL Multiplier is set to: %d\n\r", (SPLLCONbits.PLLMULT + 1));
+    printf("    Operational PLL Output Divider is set to: %d\n\r", (SPLLCONbits.PLLODIV + 1));
+    
+    printf("    Overall Operational PLL Gain is: %.3f\n\r", 
+            (float) (SPLLCONbits.PLLMULT + 1) / ((SPLLCONbits.PLLIDIV) + (SPLLCONbits.PLLODIV) + 1));
     
     
     // Determine refclk1

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.c
@@ -277,7 +277,7 @@ void clearErrorHandler(void) {
 void updateErrorLEDs(void) {
  
     // Configuration Error
-    if ( // error_handler.configuration_error_flag ||
+    if (    error_handler.configuration_error_flag ||
             error_handler.DMT_error_flag ||
             error_handler.POS12_regulation_error_flag ||
             error_handler.POS3P3_regulation_error_flag ||

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h
@@ -28,7 +28,7 @@
 
 
 // API Variables
-uint32_t device_on_time_counter;
+uint32_t device_on_time_counter __attribute__((persistent));
 
 
 // API Functions

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h
@@ -28,7 +28,7 @@
 
 
 // API Variables
-uint32_t device_on_time_counter __attribute__((persistent));
+uint32_t device_on_time_counter;
 
 
 // API Functions

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c
@@ -174,6 +174,7 @@ void main(void) {
          
             error_handler.EBI_error_flag = 1;
             updateErrorLEDs();
+            terminalTextAttributesReset();
             terminalTextAttributes(RED, BLACK, NORMAL);
             printf("EBI SRAM Initialized, but R/W self test failed\n\r");
             terminalTextAttributesReset();
@@ -182,15 +183,16 @@ void main(void) {
         }
         
         else {
-         
-            printf("EBI SRAM Initialized, R/W self test passed\n\r");
+            terminalTextAttributesReset();
+            terminalTextAttributes(GREEN, BLACK, NORMAL);
+            printf("EBI SRAM Initialized, R/W self test passed \n\r");
             clearEBISRAM();
         
         }
     
     // Initialize SPI
     spiFlashInit();
-    printf("SPI Flash Initialized\n\r");
+    printf("SPI Flash  Initialized\n\r");
     
     // Setup RNG for random pixel values
     RNGInitialize();

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-default.mk
@@ -57,17 +57,17 @@ OBJECTDIR=build/${CND_CONF}/${IMAGE_TYPE}
 DISTDIR=dist/${CND_CONF}/${IMAGE_TYPE}
 
 # Source Files Quoted if spaced
-SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c terminal_control.c test_buffer_fills.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c prefetch.c test_image_1.c main.c test_image_2.c
+SOURCEFILES_QUOTED_IF_SPACED=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c terminal_control.c test_buffer_fills.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c prefetch.c test_image_1.c test_image_2.c main.c
 
 # Object Files Quoted if spaced
-OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/terminal_control.o ${OBJECTDIR}/test_buffer_fills.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/prefetch.o ${OBJECTDIR}/test_image_1.o ${OBJECTDIR}/main.o ${OBJECTDIR}/test_image_2.o
-POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/external_bus_interface.o.d ${OBJECTDIR}/terminal_control.o.d ${OBJECTDIR}/test_buffer_fills.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/watchdog_timer.o.d ${OBJECTDIR}/prefetch.o.d ${OBJECTDIR}/test_image_1.o.d ${OBJECTDIR}/main.o.d ${OBJECTDIR}/test_image_2.o.d
+OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/terminal_control.o ${OBJECTDIR}/test_buffer_fills.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/prefetch.o ${OBJECTDIR}/test_image_1.o ${OBJECTDIR}/test_image_2.o ${OBJECTDIR}/main.o
+POSSIBLE_DEPFILES=${OBJECTDIR}/gpio_setup.o.d ${OBJECTDIR}/heartbeat_timer.o.d ${OBJECTDIR}/power_saving.o.d ${OBJECTDIR}/error_handler.o.d ${OBJECTDIR}/usb_uart.o.d ${OBJECTDIR}/panel_control.o.d ${OBJECTDIR}/spi_flash.o.d ${OBJECTDIR}/esp8266.o.d ${OBJECTDIR}/adc.o.d ${OBJECTDIR}/misc_board_control.o.d ${OBJECTDIR}/rotary_encoder.o.d ${OBJECTDIR}/external_bus_interface.o.d ${OBJECTDIR}/terminal_control.o.d ${OBJECTDIR}/test_buffer_fills.o.d ${OBJECTDIR}/device_control.o.d ${OBJECTDIR}/cause_of_reset.o.d ${OBJECTDIR}/32mz_interrupt_control.o.d ${OBJECTDIR}/watchdog_timer.o.d ${OBJECTDIR}/prefetch.o.d ${OBJECTDIR}/test_image_1.o.d ${OBJECTDIR}/test_image_2.o.d ${OBJECTDIR}/main.o.d
 
 # Object Files
-OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/terminal_control.o ${OBJECTDIR}/test_buffer_fills.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/prefetch.o ${OBJECTDIR}/test_image_1.o ${OBJECTDIR}/main.o ${OBJECTDIR}/test_image_2.o
+OBJECTFILES=${OBJECTDIR}/gpio_setup.o ${OBJECTDIR}/heartbeat_timer.o ${OBJECTDIR}/power_saving.o ${OBJECTDIR}/error_handler.o ${OBJECTDIR}/usb_uart.o ${OBJECTDIR}/panel_control.o ${OBJECTDIR}/spi_flash.o ${OBJECTDIR}/esp8266.o ${OBJECTDIR}/adc.o ${OBJECTDIR}/misc_board_control.o ${OBJECTDIR}/rotary_encoder.o ${OBJECTDIR}/external_bus_interface.o ${OBJECTDIR}/terminal_control.o ${OBJECTDIR}/test_buffer_fills.o ${OBJECTDIR}/device_control.o ${OBJECTDIR}/cause_of_reset.o ${OBJECTDIR}/32mz_interrupt_control.o ${OBJECTDIR}/watchdog_timer.o ${OBJECTDIR}/prefetch.o ${OBJECTDIR}/test_image_1.o ${OBJECTDIR}/test_image_2.o ${OBJECTDIR}/main.o
 
 # Source Files
-SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c terminal_control.c test_buffer_fills.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c prefetch.c test_image_1.c main.c test_image_2.c
+SOURCEFILES=gpio_setup.c heartbeat_timer.c power_saving.c error_handler.c usb_uart.c panel_control.c spi_flash.c esp8266.c adc.c misc_board_control.c rotary_encoder.c external_bus_interface.c terminal_control.c test_buffer_fills.c device_control.c cause_of_reset.c 32mz_interrupt_control.c watchdog_timer.c prefetch.c test_image_1.c test_image_2.c main.c
 
 
 CFLAGS=
@@ -226,17 +226,17 @@ ${OBJECTDIR}/test_image_1.o: test_image_1.c  nbproject/Makefile-${CND_CONF}.mk
 	@${RM} ${OBJECTDIR}/test_image_1.o 
 	@${FIXDEPS} "${OBJECTDIR}/test_image_1.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/test_image_1.o.d" -o ${OBJECTDIR}/test_image_1.o test_image_1.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
-${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} "${OBJECTDIR}" 
-	@${RM} ${OBJECTDIR}/main.o.d 
-	@${RM} ${OBJECTDIR}/main.o 
-	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
-	
 ${OBJECTDIR}/test_image_2.o: test_image_2.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/test_image_2.o.d 
 	@${RM} ${OBJECTDIR}/test_image_2.o 
 	@${FIXDEPS} "${OBJECTDIR}/test_image_2.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/test_image_2.o.d" -o ${OBJECTDIR}/test_image_2.o test_image_2.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
+${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/main.o.d 
+	@${RM} ${OBJECTDIR}/main.o 
+	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE) -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -fframe-base-loclist  -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
 else
 ${OBJECTDIR}/gpio_setup.o: gpio_setup.c  nbproject/Makefile-${CND_CONF}.mk
@@ -359,17 +359,17 @@ ${OBJECTDIR}/test_image_1.o: test_image_1.c  nbproject/Makefile-${CND_CONF}.mk
 	@${RM} ${OBJECTDIR}/test_image_1.o 
 	@${FIXDEPS} "${OBJECTDIR}/test_image_1.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/test_image_1.o.d" -o ${OBJECTDIR}/test_image_1.o test_image_1.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
-${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} "${OBJECTDIR}" 
-	@${RM} ${OBJECTDIR}/main.o.d 
-	@${RM} ${OBJECTDIR}/main.o 
-	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
-	
 ${OBJECTDIR}/test_image_2.o: test_image_2.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/test_image_2.o.d 
 	@${RM} ${OBJECTDIR}/test_image_2.o 
 	@${FIXDEPS} "${OBJECTDIR}/test_image_2.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/test_image_2.o.d" -o ${OBJECTDIR}/test_image_2.o test_image_2.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
+	
+${OBJECTDIR}/main.o: main.c  nbproject/Makefile-${CND_CONF}.mk
+	@${MKDIR} "${OBJECTDIR}" 
+	@${RM} ${OBJECTDIR}/main.o.d 
+	@${RM} ${OBJECTDIR}/main.o 
+	@${FIXDEPS} "${OBJECTDIR}/main.o.d" $(SILENT) -rsi ${MP_CC_DIR}../  -c ${MP_CC}  $(MP_EXTRA_CC_PRE)  -g -x c -c -mprocessor=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/main.o.d" -o ${OBJECTDIR}/main.o main.c    -DXPRJ_default=$(CND_CONF)  -legacy-libc  $(COMPARISON_BUILD) 
 	
 endif
 

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/Makefile-genesis.properties
@@ -1,8 +1,8 @@
 #
-#Mon Mar 04 19:46:55 CST 2019
+#Thu Mar 07 20:16:57 CST 2019
 default.com-microchip-mplab-nbide-toolchainXC32-XC32LanguageToolchain.md5=f03d7c843128b5e50a1f7aa63f2ccfb5
 default.languagetoolchain.dir=C\:\\Program Files (x86)\\Microchip\\xc32\\v2.10\\bin
-configurations-xml=dd817f23cfeee60a1823fac163300e04
+configurations-xml=b9c1e8be6f7fa0f17304d38ce2d4e78e
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=ddd77f39013c5d7ceec7afa039614a52
 default.languagetoolchain.version=2.10
 host.platform=windows

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/configurations.xml
@@ -323,7 +323,6 @@
         <property key="UART5" value="true"/>
         <property key="UART6" value="true"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
-        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/configurations.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/configurations.xml
@@ -4,7 +4,7 @@
   <defaultConf>0</defaultConf>
   <confs>
     <conf name="default" type="2">
-      <platformToolSN>:=MPLABComm-USB-Microchip:=&lt;vid>04D8:=&lt;pid>900A:=&lt;rev>0002:=&lt;man>Microchip Technology Inc.:=&lt;prod>PICkit 3:=&lt;sn>BUR160873112:=&lt;drv>x:=&lt;xpt>h:=end</platformToolSN>
+      <platformToolSN>:=MPLABComm-USB-Microchip:=&lt;vid>04D8:=&lt;pid>900A:=&lt;rev>0002:=&lt;man>?:=&lt;prod>?:=&lt;sn>BUR160873112:=&lt;drv>x:=&lt;xpt>b:=end</platformToolSN>
       <languageToolchainDir>C:\Program Files (x86)\Microchip\xc32\v2.10\bin</languageToolchainDir>
       <mdbdebugger version="1">
         <placeholder1>place holder 1</placeholder1>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/private.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/private.xml
@@ -4,6 +4,7 @@
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.h</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/panel_control.h</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c</file>
@@ -15,9 +16,9 @@
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/panel_control.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/cause_of_reset.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.h</file>
         </group>
     </open-files>
 </project-private>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/private.xml
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/nbproject/private/private.xml
@@ -3,22 +3,18 @@
     <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/2" lastBookmarkId="0"/>
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.h</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/test_image_1.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.h</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/panel_control.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/configure.h</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/panel_control.h</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/spi_flash.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/test_image_1.h</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/gpio_setup.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/device_control.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/test_image_1.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/panel_control.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/cause_of_reset.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/heartbeat_timer.c</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c</file>
             <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/main.c</file>
-            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/error_handler.c</file>
+            <file>file:/C:/Users/Drew%20Maatman/Documents/KiCad%20Projects/Projects/Electronic_Display/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/test_image_1.h</file>
         </group>
     </open-files>
 </project-private>

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/power_saving.c
@@ -91,7 +91,6 @@ void PMDInitialize(void) {
     PMD5bits.CAN2MD = 1;
     
     // Disable real time clock/calendar
-    // TO-DO: This may change
     PMD6bits.RTCCMD = 1;
     
     // Disable all reference clocks
@@ -114,12 +113,10 @@ void PMDInitialize(void) {
     PMD6bits.ETHMD = 1;
     
     // Disable DMA
-    // TO-DO: This may change
     PMD7bits.DMAMD = 1;
     
-    // Disable random number generator
-    // TO-DO: This may change
-    PMD7bits.RNGMD = 1;
+    // Enable random number generator
+    PMD7bits.RNGMD = 0;
     
     // Lock PMD
     PMDLock();

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
@@ -38,7 +38,7 @@ volatile uint32_t usb_uart_RxCount;
 volatile uint8_t usb_uart_RxStringReady = 0;
 
 // Printable Variables from other header files
-extern uint32_t device_on_time_counter;
+extern uint32_t device_on_time_counter __attribute__((persistent));
 extern reset_cause_t reset_cause;
 
 
@@ -426,7 +426,7 @@ void usbUartRingBufferLUT(char * line_in) {
      
         terminalTextAttributesReset();
         terminalTextAttributes(GREEN, BLACK, NORMAL);
-        printf("On time since last device reset: %s\n\r", 
+        printf("On time since last power on reset: %s\n\r", 
                 getStringSecondsAsTime(device_on_time_counter));
         terminalTextAttributesReset();
         
@@ -1274,7 +1274,7 @@ void usbUartPrintHelpMessage(void) {
     printf("    Clear: Clears the terminal\n\r");
     printf("    Cause of Reset?: Prints the cause of the most recent device reset\n\r");
     printf("    *IDN?: Prints identification string\n\r");
-    printf("    Device On Time?: Returns the device on time since last reset\n\r");
+    printf("    Device On Time?: Returns the device on time since last power on reset\n\r");
     printf("    PMD Status?: Prints the state of Peripheral Module Disable settings\n\r");
     printf("    WDT Status?: Prints the state of the watchdog timer\n\r");
     printf("    DMT Status?: Prints the state of the deadman timer\n\r");

--- a/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
+++ b/sfw/embedded_firmware/U601_firmware/LED_Display_Controller.X/usb_uart.c
@@ -38,7 +38,7 @@ volatile uint32_t usb_uart_RxCount;
 volatile uint8_t usb_uart_RxStringReady = 0;
 
 // Printable Variables from other header files
-extern uint32_t device_on_time_counter __attribute__((persistent));
+extern uint32_t device_on_time_counter;
 extern reset_cause_t reset_cause;
 
 
@@ -426,7 +426,7 @@ void usbUartRingBufferLUT(char * line_in) {
      
         terminalTextAttributesReset();
         terminalTextAttributes(GREEN, BLACK, NORMAL);
-        printf("On time since last power on reset: %s\n\r", 
+        printf("On time since last device reset: %s\n\r", 
                 getStringSecondsAsTime(device_on_time_counter));
         terminalTextAttributesReset();
         
@@ -1274,7 +1274,7 @@ void usbUartPrintHelpMessage(void) {
     printf("    Clear: Clears the terminal\n\r");
     printf("    Cause of Reset?: Prints the cause of the most recent device reset\n\r");
     printf("    *IDN?: Prints identification string\n\r");
-    printf("    Device On Time?: Returns the device on time since last power on reset\n\r");
+    printf("    Device On Time?: Returns the device on time since last reset\n\r");
     printf("    PMD Status?: Prints the state of Peripheral Module Disable settings\n\r");
     printf("    WDT Status?: Prints the state of the watchdog timer\n\r");
     printf("    DMT Status?: Prints the state of the deadman timer\n\r");
@@ -1323,7 +1323,6 @@ void usbUartPrintHelpMessage(void) {
     printf("    Set Test Image 1: Loads RAM buffer with data for the first test image\n\r");
     printf("    Set Test Image 2: Loads RAM buffer with data for the second test image\n\r");
     printf("    Set Rand: Sets pixels to display random data\n\r");
-    printf("    Set Rand Seed <x>: Sets the random number seet to the given number x\n\r");
     printf("    Set Every Other Red: Fills ram buffer with stripes of red\n\r");
     printf("    Set Every Other Blue: Fills ram buffer with stripes of blue\n\r");
     printf("    Set Every Other Green: Fills ram buffer with stripes of green\n\r");


### PR DESCRIPTION
Fixed flash ECC error bug that was occurring on boot when loading configuration words from flash into DEVCFG registers. No more red LEDs on boot (for now). A commit message includes setting device_on_time to persistent but that was since removed.